### PR TITLE
use @gcloud/datastore instead to reduce dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/Release
 node_modules
 
 .tmp/
+credentials.json
+.env

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "bugs": {
     "url": "https://github.com/fabito/botkit-storage-datastore/issues"
-  },  
+  },
   "dependencies": {
-    "google-cloud": "^0.53.0"
+    "@google-cloud/datastore": "^1.4.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var gcloud = require('google-cloud');
+var Datastore = require('@google-cloud/datastore');
 
 /**
  * The Botkit google cloud datastore driver
@@ -11,7 +11,7 @@ module.exports = function(config) {
         throw new Error('projectId is required.');
     }
 
-    var datastore = gcloud.datastore(config),
+    var datastore = Datastore(config),
         namespace = config.namespace,
         teamKind = config.teamKind || 'BotkitTeam',
         channelKind = config.channelKind || 'BotkitChannel',

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,7 +5,7 @@ var should = require('should'),
 require('should-sinon');
 
 describe('Datastore', function() {
-    var gcloudMock,
+    var GCloudDatastore,
         datastoreMock,
         Storage;
 
@@ -21,12 +21,10 @@ describe('Datastore', function() {
             runQuery: sinon.stub()
         };
 
-        gcloudMock = {
-            datastore: sinon.stub().returns(datastoreMock)
-        };
+        GCloudDatastore = sinon.stub().returns(datastoreMock);
 
         Storage = proxyquire('../src/index', {
-            'google-cloud': gcloudMock
+            '@google-cloud/datastore': GCloudDatastore
         });
 
     });
@@ -44,7 +42,7 @@ describe('Datastore', function() {
         it('should initialize datastore with projectId', function() {
             var config = {projectId: 'crystalbluepersuation'};
             Storage(config);
-            gcloudMock.datastore.should.be.calledWith(config);
+            GCloudDatastore.should.be.calledWith(config);
         });
     });
 

--- a/tests/it.js
+++ b/tests/it.js
@@ -3,7 +3,7 @@
 var DatastoreStorage = require('../src');
 
 var storage = new DatastoreStorage({
-	projectId: 'myproject',
+	projectId: process.env.projectId || 'myproject',
 	namespace: '---botkit---'
 	//,apiEndpoint: 'http://localhost:8888'
 });


### PR DESCRIPTION
* using @google-cloud/datastore reduced the overall dependencies needed, meaning faster install and smaller node_modules
* updated test

## Migration Needed
* test environment needs `process.env.projectId` = `myproject`
### Test Results

```
➜  botkit-storage-datastore git:(feature/smaller-dependencies) npm test


  Datastore
    init
      ✓ should require a config
      ✓ should require projectId
      ✓ should initialize datastore with projectId
    key
      ✓ should use custom kind
    get
      ✓ should get entity
      ✓ should handle non existent entity
      ✓ should call callback on error
    get from namespace
      ✓ should get entity
      ✓ should handle non existent entity
      ✓ should call callback on error
    save
      ✓ should call datastore save
    save into namespace
      ✓ should call datastore save
    all
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error
    all from namespace
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error
    key
      ✓ should use custom kind
    get
      ✓ should get entity
      ✓ should handle non existent entity
      ✓ should call callback on error
    get from namespace
      ✓ should get entity
      ✓ should handle non existent entity
      ✓ should call callback on error
    save
      ✓ should call datastore save
    save into namespace
      ✓ should call datastore save
    all
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error
    all from namespace
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error
    key
      ✓ should use custom kind
    get
      ✓ should get entity
      ✓ should handle non existent entity
[]
      ✓ should call callback on error
    get from namespace
      ✓ should get entity
      ✓ should handle non existent entity
      ✓ should call callback on error
    save
      ✓ should call datastore save
    save into namespace
      ✓ should call datastore save
    all
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error
    all from namespace
      ✓ should get records
      ✓ should handle no records
      ✓ should call callback on error


  48 passing (806ms)

=============================================================================
Writing coverage object [/mnt/c/Users/AnthonyMetzidis/sotion/botkit-storage-datastore/coverage/coverage.json]
Writing coverage reports at [/mnt/c/Users/AnthonyMetzidis/sotion/botkit-storage-datastore/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 100% ( 35/35 )
Branches     : 100% ( 24/24 )
Functions    : 100% ( 10/10 )
Lines        : 100% ( 35/35 )
```